### PR TITLE
Document WAVECAR RECL compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Berry curvature and Chern number calculations with the output (WAVECAR) of VASP 
 VASPBERRY is written for the post-processing purpose of the VASP outputs, i.e., WAVECAR the Bloch wavefunction information. VASPBERRY can compute Berry curvature and Chern number via Fukui's method [See J. Phys. Soc. Jap. 74, 1674 (2005)]. In addition Circular dichroism also can be evaluated. Since it directly reads the wavefunction coefficients, one can also obtain real space wavefunction character psi_nk(r) by simple command.
 
 # Download Git version
-* git clone --branch master  https://github.com/Infant83/TBFIT.git
+* git clone --branch master  https://github.com/Infant83/VASPBERRY.git
 
 # Compile
 * Serial version : 
@@ -15,6 +15,14 @@ VASPBERRY is written for the post-processing purpose of the VASP outputs, i.e., 
     For gfortran, please use vaspberry_gfortran_serial.f for the compilation. This only support non-parallel calculations.
     For the compilation, for example
     > gfortran -L/usr/local/lib/lapack/ -l lapack -o vaspberry vaspberry_gfortran_serial.f
+
+> **WAVECAR compatibility:** The VASP writer and VASPBERRY reader must
+> use the same direct-access `RECL` convention. Byte-based `RECL` is
+> recommended; with Intel Fortran, compile both using
+> `-assume byterecl`. If the first WAVECAR header is readable but
+> `NKPOINT`, `NBANDS`, or `ENCUT` is zero/invalid, or the lattice
+> vectors are `NaN`, suspect a 4-byte `RECL` mismatch. Rebuilding VASP
+> with byte `RECL` and regenerating `WAVECAR` is the preferred fix.
 
 # Features
 * Berry curvature calculation

--- a/vaspberry.f
+++ b/vaspberry.f
@@ -3813,6 +3813,9 @@
       character*256 filename
       dimension a1(3),a2(3),a3(3)
 
+! The WAVECAR header stores VASP's logical direct-access record length.
+! VASPBERRY must use the same RECL unit as the VASP writer.
+! With ifort, byte RECL requires -assume byterecl for both programs.
       irecl=24
       open(unit=10,file=filename,access='direct',recl=irecl,
      & iostat=iost,status='old')
@@ -4232,8 +4235,21 @@
      &-kp 1"
       write(6,*)"* here, VBM is valence band maximum"
       write(6,*)" "
-      write(6,*)"*Compilation:  gfortran or ifort. "
-      write(6,*)" Flag '-assume byterecl' is required for ifort."
+      write(6,*)"*Compilation: gfortran or ifort."
+      write(6,*)"*WAVECAR compatibility:"
+      write(6,*)" VASP and VASPBERRY must use the same direct-access"
+      write(6,*)" RECL unit. Byte RECL is recommended."
+      write(6,*)" With ifort, compile both VASP and VASPBERRY using"
+      write(6,*)" '-assume byterecl'. The supplied gfortran version"
+      write(6,*)" uses byte RECL."
+      write(6,*)" A RECL mismatch may leave the first WAVECAR header"
+      write(6,*)" valid, but give zero/invalid NKPOINT, NBANDS,"
+      write(6,*)" ENCUT, or NaN lattice vectors."
+      write(6,*)" Preferred fix: rebuild VASP with byte RECL and"
+      write(6,*)" regenerate WAVECAR."
+      write(6,*)" A VASPBERRY built without '-assume byterecl' may"
+      write(6,*)" read such a legacy WAVECAR, but use it only for"
+      write(6,*)" files written with that same RECL convention."
       write(6,*)" for OSX,  -Wl,-stack_size,0x80000000 may be required"
       write(6,*)" ex-noMPI)ifort -fpp -assume byterecl -mkl 
      &-o vaspberry vaspberry.f"

--- a/vaspberry_gfortran_serial.f
+++ b/vaspberry_gfortran_serial.f
@@ -2295,6 +2295,9 @@
       character*75 filename
       dimension a1(3),a2(3),a3(3)
 
+! The WAVECAR header stores VASP's logical direct-access record length.
+! VASPBERRY must use the same RECL unit as the VASP writer.
+! With ifort, byte RECL requires -assume byterecl for both programs.
       irecl=24
       open(unit=10,file=filename,access='direct',recl=irecl,
      & iostat=iost,status='old')
@@ -2649,8 +2652,21 @@
      &-kp 1"
       write(6,*)"* here, VBM is valence band maximum"
       write(6,*)" "
-      write(6,*)"*Compilation:  gfortran or ifort. "
-      write(6,*)" Flag '-assume byterecl' is required for ifort."
+      write(6,*)"*Compilation: gfortran or ifort."
+      write(6,*)"*WAVECAR compatibility:"
+      write(6,*)" VASP and VASPBERRY must use the same direct-access"
+      write(6,*)" RECL unit. Byte RECL is recommended."
+      write(6,*)" With ifort, compile both VASP and VASPBERRY using"
+      write(6,*)" '-assume byterecl'. The supplied gfortran version"
+      write(6,*)" uses byte RECL."
+      write(6,*)" A RECL mismatch may leave the first WAVECAR header"
+      write(6,*)" valid, but give zero/invalid NKPOINT, NBANDS,"
+      write(6,*)" ENCUT, or NaN lattice vectors."
+      write(6,*)" Preferred fix: rebuild VASP with byte RECL and"
+      write(6,*)" regenerate WAVECAR."
+      write(6,*)" A VASPBERRY built without '-assume byterecl' may"
+      write(6,*)" read such a legacy WAVECAR, but use it only for"
+      write(6,*)" files written with that same RECL convention."
       write(6,*)" for OSX,  -Wl,-stack_size,0x80000000 may be required"
       write(6,*)" ex-noMPI)ifort -fpp -assume byterecl -mkl 
      &-o vaspberry vaspberry.f"


### PR DESCRIPTION
## Summary
- clarify that the VASP writer and VASPBERRY reader must use the same direct-access `RECL` convention
- expand the built-in `-h` guidance in both source variants
- add maintenance comments near the WAVECAR header reader
- describe common symptoms of a byte versus 4-byte-word `RECL` mismatch
- correct the README clone URL

## Verification
- inserted fixed-form Fortran lines are at most 71 columns
- both duplicated help blocks contain identical guidance
- WAVECAR parsing behavior is unchanged